### PR TITLE
added nvidia jetson hw support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Recently the state space models (SSMs) with efficient hardware-aware designs, i.
 - Requirements: vim_requirements.txt
   - `pip install -r vim/vim_requirements.txt`
 
-- Install ``causal_conv1d`` and ``mamba``
-  - `pip install -e causal_conv1d>=1.1.0`
+- Install ``causal-conv1d`` and ``mamba``
+  - `pip install -e causal-conv1d>=1.1.0`
   - `pip install -e mamba-1p1p1`
   
   

--- a/causal-conv1d/setup.py
+++ b/causal-conv1d/setup.py
@@ -104,10 +104,13 @@ if not SKIP_CUDA_BUILD:
                 "Note: make sure nvcc has a supported version by running nvcc -V."
             )
 
-    cc_flag.append("-gencode")
     cc_flag.append("arch=compute_70,code=sm_70")
     cc_flag.append("-gencode")
+    cc_flag.append("arch=compute_72,code=sm_72")
+    cc_flag.append("-gencode")
     cc_flag.append("arch=compute_80,code=sm_80")
+    cc_flag.append("-gencode")
+    cc_flag.append("arch=compute_87,code=sm_87")
     if bare_metal_version >= Version("11.8"):
         cc_flag.append("-gencode")
         cc_flag.append("arch=compute_90,code=sm_90")

--- a/mamba-1p1p1/setup.py
+++ b/mamba-1p1p1/setup.py
@@ -105,10 +105,13 @@ if not SKIP_CUDA_BUILD:
                 "Note: make sure nvcc has a supported version by running nvcc -V."
             )
 
-    cc_flag.append("-gencode")
     cc_flag.append("arch=compute_70,code=sm_70")
     cc_flag.append("-gencode")
+    cc_flag.append("arch=compute_72,code=sm_72")
+    cc_flag.append("-gencode")
     cc_flag.append("arch=compute_80,code=sm_80")
+    cc_flag.append("-gencode")
+    cc_flag.append("arch=compute_87,code=sm_87")
     if bare_metal_version >= Version("11.8"):
         cc_flag.append("-gencode")
         cc_flag.append("arch=compute_90,code=sm_90")


### PR DESCRIPTION
Hello @Unrealluver 

Thank you for releasing the code for Vim. This is a PR to support nvidia jetson GPUs. With Vim's efficiency, it would be really interesting to see their performance compared to convnets and transformers on this platform. 

The `setup.py` has been modified for both `mamba_ssm` and `causal-conv1d` as seen in the below PRs

https://github.com/state-spaces/mamba/pull/262
https://github.com/Dao-AILab/causal-conv1d/pull/20

I have added Jetson support with CUDA compatibility > 70 as `triton` has a minimum CUDA compatibility of 70

I have also modified `README.md` to fix a small typo

Let me know if further changes are required