### PR TITLE
Update models_mamba.py

### DIFF
--- a/vim/models_mamba.py
+++ b/vim/models_mamba.py
@@ -492,8 +492,8 @@ class VisionMamba(nn.Module):
                 hidden_states_b, residual_b = self.layers[i * 2 + 1](
                     hidden_states.flip([1]), None if residual == None else residual.flip([1]), inference_params=inference_params
                 )
-                hidden_states = hidden_states_f + hidden_states_b.flip([1])
-                residual = residual_f + residual_b.flip([1])
+                hidden_states = (hidden_states_f + hidden_states_b.flip([1])) / 2
+                residual = (residual_f + residual_b.flip([1])) / 2
 
         if not self.fused_add_norm:
             if residual is None:


### PR DESCRIPTION
While trying to train vision mamba with bidirectional mode in masked autoencoder network, I experienced nan loss. Though switch training from mixed precision to full precision fixed the problem but significantly increased training time (almost twice).  Looking at the code, the adding of forward and backward hidden_states/residuals does increased the magnitude of both twice as compared to the original hidden states (after patch embedding). By dividing by 2, nan loss was resolved and mixed precision training can continue.